### PR TITLE
Make test runner work on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,19 @@ if (NOT WIN32)
     list(APPEND TEST_SRC_FILES noisereduction/tests/test_mmap_snd.cpp)
 endif()
 
-add_executable(test_runner ${TEST_SRC_FILES})
+# Add headers as well so they are listed in Visual Studio
+set(TEST_HEADER_FILES
+	noisereduction/tests/catch.hpp
+)
+
+add_executable(test_runner ${TEST_SRC_FILES} ${TEST_HEADER_FILES})
+
+# Define samples directory relative to executable
+if(MSVC)
+	# two levels up because MSVC puts exe under build/Debug
+	target_compile_definitions(test_runner PRIVATE SAMPLES_DIR="../../samples")
+else()
+	target_compile_definitions(test_runner PRIVATE SAMPLES_DIR="../samples")
+endif()
 
 target_link_libraries(test_runner PRIVATE noisereduction_core)

--- a/noisereduction/tests/test_audacity.cpp
+++ b/noisereduction/tests/test_audacity.cpp
@@ -50,9 +50,9 @@ void compare(const char* inputPath, const char* groundTruthPath) {
         outputTracks.push_back(outputTrack);
     }
 
-    TrackUtils::writeTracksToFile("/tmp/processed.wav", outputTracks, inputCtx.info.channels, inputCtx.info.samplerate);
+    TrackUtils::writeTracksToFile("./temp/processed.wav", outputTracks, inputCtx.info.channels, inputCtx.info.samplerate);
 
-    SndContext processedCtx = TrackUtils::openAudioFile("/tmp/processed.wav");
+    SndContext processedCtx = TrackUtils::openAudioFile("./temp/processed.wav");
     REQUIRE(processedCtx.info.frames == groundTruthCtx.info.frames);
     REQUIRE(processedCtx.info.channels == groundTruthCtx.info.channels);
 
@@ -70,10 +70,10 @@ void compare(const char* inputPath, const char* groundTruthPath) {
 
 TEST_CASE( "Noise Reduction", "[NoiseReduction]" ) {
     SECTION( "mono track" ) {
-        compare("dtmf-noise-mono.wav", "dtmf-noise-mono-audacity-gain-39-sensitivity-16-smooth-0.wav");
+        compare(SAMPLES_DIR "/dtmf-noise-mono.wav", SAMPLES_DIR "/dtmf-noise-mono-audacity-gain-39-sensitivity-16-smooth-0.wav");
     }
 
     SECTION( "stereo track" ) {
-        compare("dtmf-noise-stereo.wav", "dtmf-noise-stereo-audacity-gain-39-sensitivity-16-smooth-0.wav");
+        compare(SAMPLES_DIR "/dtmf-noise-stereo.wav", SAMPLES_DIR "/dtmf-noise-stereo-audacity-gain-39-sensitivity-16-smooth-0.wav");
     }
 }

--- a/noisereduction/tests/test_mmap_snd.cpp
+++ b/noisereduction/tests/test_mmap_snd.cpp
@@ -44,9 +44,9 @@ void checkRead(SndContext& mmapCtx, SndContext& rawCtx, size_t frames, size_t bu
 
 TEST_CASE( "MMapped SND", "[MmapSnd]" ) {
     SECTION("Reading everything in one go") {
-        SndMmap sndMmaped("dtmf-noise-mono.wav");
+        SndMmap sndMmaped(SAMPLES_DIR "/dtmf-noise-mono.wav");
         SndContext mmapCtx = sndMmaped.Open();
-        SndContext rawCtx = openAudioFileRawIO("dtmf-noise-mono.wav");
+        SndContext rawCtx = openAudioFileRawIO(SAMPLES_DIR "/dtmf-noise-mono.wav");
 
         REQUIRE(mmapCtx.file);
         REQUIRE(rawCtx.file);
@@ -55,9 +55,9 @@ TEST_CASE( "MMapped SND", "[MmapSnd]" ) {
     }
 
     SECTION("Seeking") {
-        SndMmap sndMmaped("dtmf-noise-mono.wav");
+        SndMmap sndMmaped(SAMPLES_DIR "/dtmf-noise-mono.wav");
         SndContext mmapCtx = sndMmaped.Open();
-        SndContext rawCtx = openAudioFileRawIO("dtmf-noise-mono.wav");
+        SndContext rawCtx = openAudioFileRawIO(SAMPLES_DIR "/dtmf-noise-mono.wav");
 
         REQUIRE(mmapCtx.file);
         REQUIRE(rawCtx.file);
@@ -70,9 +70,9 @@ TEST_CASE( "MMapped SND", "[MmapSnd]" ) {
     }
 
     SECTION("Read batches") {
-        SndMmap sndMmaped("dtmf-noise-mono.wav");
+        SndMmap sndMmaped(SAMPLES_DIR "/dtmf-noise-mono.wav");
         SndContext mmapCtx = sndMmaped.Open();
-        SndContext rawCtx = openAudioFileRawIO("dtmf-noise-mono.wav");
+        SndContext rawCtx = openAudioFileRawIO(SAMPLES_DIR "/dtmf-noise-mono.wav");
 
         REQUIRE(mmapCtx.file);
         REQUIRE(rawCtx.file);

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,8 @@
+mkdir build
+cd build
+cmake ..
+cmake --build . --target test_runner
+cd Debug
+mkdir temp
+.\test_runner.exe
+PAUSE

--- a/test.sh
+++ b/test.sh
@@ -3,5 +3,5 @@ mkdir -p build
 cd build
 cmake ..
 cmake --build . --target test_runner
-cd ../samples
-../build/test_runner
+mkdir -p temp
+./test_runner


### PR DESCRIPTION
Therefore, added test.bat and also adjusted test.sh and test code
Start test runner from directory of executable instead of samples directory
Adjusted paths in code to be relative to executable dir
Use compile definition for samples dir because different with MSVC
Creating local temp dir instead of using /tmp so it works on Windows